### PR TITLE
ci(commit): workflow to request author to squash commits

### DIFF
--- a/.github/workflows/require-clean-commit.yml
+++ b/.github/workflows/require-clean-commit.yml
@@ -1,0 +1,39 @@
+name: Require cleaning up PR commits
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: write
+
+jobs:
+  request-cleanup:
+    if: ${{ github.event.label.name == 'clean-commit-required' && github.event.pull_request.commits > 1  }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Request author to squash commits
+      uses: thollander/actions-comment-pull-request@v1
+      with:
+        message: |-
+          Please clean up PR commit history by squashing into a single commit.
+
+          Example:
+
+          ```bash
+          $ git reset ${{ github.base_ref }}
+          $ git add --all
+          $ git commit -m '${{ github.event.pull_request.title }}'
+          ```
+  remove-request-label:
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'clean-commit-required') && github.event.pull_request.commits == 1 }}
+    steps:
+      - name: Remove label clean-commit-required
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: clean-commit-required


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat3/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and last commit is ["signed-off"](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff): `git commit -S -s -m "YOUR_COMMIT_MESSAGE"`
_______________________________________________

Related to #4 

## Description of the change:

Add workflow that requests author to squash commit (i.e. by adding a label). Also, automatically remove label when done squashing.
